### PR TITLE
better tests

### DIFF
--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -36,8 +36,6 @@ if(GMSHPARSERCPP_CODE_COVERAGE)
             --ignore-filename-regex=/include/gtest/*
             --ignore-filename-regex=/include/gmock/*
             --ignore-filename-regex=test/*
-            --ignore-filename-regex=gmshparsercppMshLexer.cpp
-            --ignore-filename-regex=FlexLexer.h
         )
 
         set(CODE_COVERAGE_BINS
@@ -123,8 +121,6 @@ if(GMSHPARSERCPP_CODE_COVERAGE)
             --exclude=*/include/gmock/*
             --exclude=*/include/fmt/*
             --exclude=/usr/include/*
-            --exclude=gmshparsercppMshLexer.cpp
-            --exclude=FlexLexer.h
         )
 
         add_custom_target(coverage DEPENDS ${COVERAGE_INFO})

--- a/include/gmshparsercpp/Exception.h
+++ b/include/gmshparsercpp/Exception.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <exception>
+#include <string>
+#include <vector>
+#include "fmt/format.h"
+
+namespace gmshparsercpp {
+
+/// Exception thrown from our code, so that application code can determine where problems originated
+/// from
+class Exception : public std::exception {
+public:
+    template <typename... T>
+    Exception(fmt::format_string<T...> format, T... args)
+    {
+        this->msg = fmt::format(format, std::forward<T>(args)...);
+    }
+
+    /// Get the exception message
+    const char * what() const noexcept override;
+
+private:
+    /// Error message
+    std::string msg;
+};
+
+} // namespace gmshparsercpp

--- a/include/gmshparsercpp/MshFile.h
+++ b/include/gmshparsercpp/MshFile.h
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <vector>
 #include "gmshparsercpp/Enums.h"
+#include "gmshparsercpp/Exception.h"
 #include "gmshparsercpp/MshLexer.h"
 
 namespace gmshparsercpp {

--- a/include/gmshparsercpp/MshFile.h
+++ b/include/gmshparsercpp/MshFile.h
@@ -90,6 +90,7 @@ public:
         double x, y, z;
 
         Point() : x(0.), y(0.), z(0.) {}
+        Point(double x, double y, double z) : x(x), y(y), z(z) {}
     };
 
     struct Node {

--- a/include/gmshparsercpp/MshFile.h
+++ b/include/gmshparsercpp/MshFile.h
@@ -189,6 +189,18 @@ public:
     /// Close the file
     void close();
 
+    /// Get the number of nodes per element type
+    ///
+    /// @param element_type GMSH element type
+    /// @return Number of nodes per element
+    static int get_nodes_per_element(ElementType element_type);
+
+    /// Get element dimension
+    ///
+    /// @param element_type GMSH element type
+    /// @return Dimension
+    static int get_element_dimension(ElementType element_type);
+
 protected:
     void process_section(const MshLexer::Token & token);
     void process_mesh_format_section();
@@ -203,8 +215,6 @@ protected:
     std::vector<int> process_array_of_ints();
     void skip_section();
     void read_end_section_marker(const std::string & section_name);
-    int get_nodes_per_element(ElementType element_type);
-    int get_element_dimension(ElementType element_type);
     ElementBlock & get_element_block_by_tag_create(int tag);
 
     /// File name

--- a/include/gmshparsercpp/MshLexer.h
+++ b/include/gmshparsercpp/MshLexer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <fstream>
+#include "gmshparsercpp/Exception.h"
 
 namespace gmshparsercpp {
 
@@ -20,7 +21,7 @@ public:
         T
         as() const
         {
-            throw std::runtime_error("Unsupported type");
+            throw Exception("Unsupported type");
         }
     };
 
@@ -79,7 +80,7 @@ MshLexer::Token::as() const
     if (this->type == Number)
         return std::stoi(this->str);
     else
-        throw std::domain_error("Token is not a number");
+        throw Exception("Token is not a number");
 }
 
 template <>
@@ -89,7 +90,7 @@ MshLexer::Token::as() const
     if (this->type == Number)
         return std::stol(this->str);
     else
-        throw std::domain_error("Token is not a number");
+        throw Exception("Token is not a number");
 }
 
 template <>
@@ -99,7 +100,7 @@ MshLexer::Token::as() const
     if (this->type == Number)
         return std::stod(this->str);
     else
-        throw std::domain_error("Token is not a number");
+        throw Exception("Token is not a number");
 }
 
 template <>
@@ -109,7 +110,7 @@ MshLexer::Token::as() const
     if (this->type == String)
         return this->str;
     else
-        throw std::domain_error("Token is not a string");
+        throw Exception("Token is not a string");
 }
 
 } // namespace gmshparsercpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(${PROJECT_NAME}
     ${GMSHPARSERCPP_LIBRARY_TYPE}
+        Exception.cpp
         MshFile.cpp
         MshLexer.cpp
 )

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -1,0 +1,11 @@
+#include "gmshparsercpp/Exception.h"
+
+namespace gmshparsercpp {
+
+const char *
+Exception::what() const noexcept
+{
+    return this->msg.c_str();
+}
+
+} // namespace gmshparsercpp

--- a/src/MshFile.cpp
+++ b/src/MshFile.cpp
@@ -140,11 +140,11 @@ MshFile::process_mesh_format_section()
     int maj_ver = this->version;
     if (maj_ver == 2) {
         if (data_size != sizeof(double))
-            throw Exception("Unexpected data size found {}.", data_size);
+            throw Exception("Unexpected data size found: {}", data_size);
     }
     else if (maj_ver == 4) {
         if (data_size != sizeof(size_t))
-            throw Exception("Unexpected data size found {}.", data_size);
+            throw Exception("Unexpected data size found: {}", data_size);
         if (this->binary)
             this->endianness = this->lexer.read_blob<int>();
     }

--- a/src/MshFile.cpp
+++ b/src/MshFile.cpp
@@ -138,12 +138,10 @@ MshFile::process_mesh_format_section()
     this->binary = this->lexer.read().as<int>() == 1;
     auto data_size = this->lexer.read().as<int>();
     int maj_ver = this->version;
-    if (maj_ver == 2) {
-        if (data_size != sizeof(double))
+    if (maj_ver == 2 || maj_ver == 4) {
+        if ((maj_ver == 2) && (data_size != sizeof(double)))
             throw Exception("Unexpected data size found: {}", data_size);
-    }
-    else if (maj_ver == 4) {
-        if (data_size != sizeof(size_t))
+        else if ((maj_ver == 4) && (data_size != sizeof(size_t)))
             throw Exception("Unexpected data size found: {}", data_size);
         if (this->binary)
             this->endianness = this->lexer.read_blob<int>();
@@ -331,7 +329,7 @@ MshFile::process_elements_section_v2()
                 auto ent = this->lexer.get<int>();
                 auto n_elem_nodes = get_nodes_per_element(el_type);
                 for (auto j = 0; j < n_elem_nodes; j++) {
-                    auto nid = this->lexer.get<size_t>();
+                    auto nid = this->lexer.get<int>();
                     el.node_tags.push_back(nid);
                 }
                 auto & blk = get_element_block_by_tag_create(phys);

--- a/src/MshFile.cpp
+++ b/src/MshFile.cpp
@@ -13,8 +13,7 @@ MshFile::MshFile(const std::string & file_name) :
     endianness(0)
 {
     if (!this->file.is_open())
-        throw std::system_error(std::error_code(),
-                                fmt::sprintf("Unable to open file '%s'.", this->file_name));
+        throw Exception("Unable to open file '{}'.", this->file_name);
 }
 
 MshFile::~MshFile()
@@ -86,7 +85,7 @@ MshFile::parse()
             process_section(token);
         }
         else
-            throw std::runtime_error("Expected start of section marker not found.");
+            throw Exception("Expected start of section marker not found.");
         token = this->lexer.peek();
     } while (token.type != MshLexer::Token::EndOfFile);
 }
@@ -129,7 +128,7 @@ MshFile::read_end_section_marker(const std::string & section_name)
 {
     auto sct_end = this->lexer.read();
     if (sct_end.type != MshLexer::Token::Section || sct_end.str != section_name)
-        throw std::runtime_error(fmt::sprintf("%s tag not found.", section_name));
+        throw Exception("{} tag not found.", section_name);
 }
 
 void
@@ -141,16 +140,16 @@ MshFile::process_mesh_format_section()
     int maj_ver = this->version;
     if (maj_ver == 2) {
         if (data_size != sizeof(double))
-            throw std::runtime_error(fmt::format("Unexpected data size found {}.", data_size));
+            throw Exception("Unexpected data size found {}.", data_size);
     }
     else if (maj_ver == 4) {
         if (data_size != sizeof(size_t))
-            throw std::runtime_error(fmt::format("Unexpected data size found {}.", data_size));
+            throw Exception("Unexpected data size found {}.", data_size);
         if (this->binary)
             this->endianness = this->lexer.read_blob<int>();
     }
     else
-        throw std::runtime_error(fmt::format("Unsupported version {}", this->version));
+        throw Exception("Unsupported version {}", this->version);
 
     read_end_section_marker("$EndMeshFormat");
 
@@ -455,7 +454,7 @@ MshFile::get_nodes_per_element(ElementType element_type)
         case HEX64: return 64;
         case HEX125: return 125;
         default:
-            throw std::domain_error(fmt::sprintf("Unknown element type '%d'", element_type));
+            throw Exception("Unknown element type '{}'", element_type);
     }
     // clang-format on
 }
@@ -506,7 +505,7 @@ MshFile::get_element_dimension(ElementType element_type)
         return 3;
 
     default:
-        throw std::domain_error(fmt::sprintf("Unknown element type '%d'", element_type));
+        throw Exception("Unknown element type '{}'", element_type);
     }
 }
 

--- a/src/MshLexer.cpp
+++ b/src/MshLexer.cpp
@@ -99,7 +99,7 @@ MshLexer::read_char()
     char ch;
     this->in->read(&ch, sizeof(ch));
     if (ch == EOF)
-        throw std::runtime_error("Reached end of file");
+        throw Exception("Reached end of file");
     return ch;
 }
 
@@ -108,7 +108,7 @@ MshLexer::peek_char()
 {
     auto ch = this->in->peek();
     if (ch == EOF)
-        throw std::runtime_error("Reached end of file");
+        throw Exception("Reached end of file");
     return ch;
 }
 

--- a/test/ExceptionTestMacros.h
+++ b/test/ExceptionTestMacros.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "gmshparsercpp/Exception.h"
+
+/// Test that the `cmd` will throw `godzilla::Exception` with message `msg`
+#define EXPECT_THROW_MSG(cmd, msg)   \
+    try {                            \
+        cmd;                         \
+        FAIL();                      \
+    }                                \
+    catch (Exception & e) {          \
+        EXPECT_STREQ(e.what(), msg); \
+    }                                \
+    catch (...) {                    \
+        FAIL();                      \
+    }
+
+#define EXPECT_THAT_THROW_MSG(cmd, matcher) \
+    try {                                   \
+        cmd;                                \
+        FAIL();                             \
+    }                                       \
+    catch (Exception & e) {                 \
+        EXPECT_THAT(e.what(), matcher);     \
+    }                                       \
+    catch (...) {                           \
+        FAIL();                             \
+    }

--- a/test/MshFile_test.cpp
+++ b/test/MshFile_test.cpp
@@ -1,5 +1,6 @@
 #include <gmock/gmock.h>
 #include "TestConfig.h"
+#include "ExceptionTestMacros.h"
 #include "gmshparsercpp/MshFile.h"
 
 using namespace gmshparsercpp;
@@ -7,14 +8,14 @@ using namespace testing;
 
 TEST(MshFileTest, empty)
 {
-    EXPECT_THROW(
+    EXPECT_THROW_MSG(
         {
             std::string file_name =
                 std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/empty.msh");
             MshFile f(file_name);
             f.parse();
         },
-        std::runtime_error);
+        "Expected start of section marker not found.");
 }
 
 TEST(MshFileTest, header)

--- a/test/MshFile_test.cpp
+++ b/test/MshFile_test.cpp
@@ -46,7 +46,6 @@ TEST(MshFileTest, missing_end_section_marker)
         "$EndMeshFormat tag not found.");
 }
 
-
 TEST(MshFileTest, unsupported_version)
 {
     std::string file_name =
@@ -253,4 +252,46 @@ TEST(MshFileTest, two_blk)
 
     auto el_blks = f.get_element_blocks();
     EXPECT_EQ(el_blks.size(), 8);
+}
+
+TEST(MshFileTest, element_dim)
+{
+    std::vector<gmshparsercpp::ElementType> d0 = { POINT };
+    for (auto & d : d0)
+        EXPECT_EQ(MshFile::get_element_dimension(d), 0);
+
+    std::vector<gmshparsercpp::ElementType> d1 = { LINE2, LINE3, LINE4, LINE5, LINE6 };
+    for (auto & d : d1)
+        EXPECT_EQ(MshFile::get_element_dimension(d), 1);
+
+    std::vector<gmshparsercpp::ElementType> d2 = { TRI3,  QUAD4,  TRI6,  QUAD9,  QUAD8, ITRI9,
+                                                   TRI10, ITRI12, TRI15, ITRI15, TRI21 };
+    for (auto & d : d2)
+        EXPECT_EQ(MshFile::get_element_dimension(d), 2);
+
+    std::vector<gmshparsercpp::ElementType> d3 = { TET4,  HEX8,    PRISM6,    PYRAMID5,
+                                                   TET10, HEX27,   PRISM18,   PYRAMID14,
+                                                   HEX20, PRISM15, PYRAMID13, TET20,
+                                                   TET35, TET56,   HEX64,     HEX125 };
+    for (auto & d : d3)
+        EXPECT_EQ(MshFile::get_element_dimension(d), 3);
+
+    EXPECT_THROW_MSG(MshFile::get_element_dimension(NONE), "Unknown element type '-1'");
+}
+
+TEST(MshFileTest, num_element_nodes)
+{
+    std::vector<std::pair<ElementType, int>> nodes = {
+        { LINE2, 2 },  { TRI3, 3 },     { QUAD4, 4 },    { TET4, 4 },       { HEX8, 8 },
+        { PRISM6, 6 }, { PYRAMID5, 5 }, { LINE3, 3 },    { TRI6, 6 },       { QUAD9, 9 },
+        { TET10, 10 }, { HEX27, 27 },   { PRISM18, 18 }, { PYRAMID14, 14 }, { POINT, 1 },
+        { QUAD8, 8 },  { HEX20, 20 },   { PRISM15, 15 }, { PYRAMID13, 13 }, { ITRI9, 9 },
+        { TRI10, 10 }, { ITRI12, 12 },  { TRI15, 15 },   { ITRI15, 15 },    { TRI21, 21 },
+        { LINE4, 4 },  { LINE5, 5 },    { LINE6, 6 },    { TET20, 20 },     { TET35, 35 },
+        { TET56, 56 }, { HEX64, 64 },   { HEX125, 125 }
+    };
+    for (auto & n : nodes)
+        EXPECT_EQ(MshFile::get_nodes_per_element(n.first), n.second);
+
+    EXPECT_THROW_MSG(MshFile::get_nodes_per_element(NONE), "Unknown element type '-1'");
 }

--- a/test/MshFile_test.cpp
+++ b/test/MshFile_test.cpp
@@ -59,6 +59,30 @@ TEST(MshFileTest, unsupported_version)
         "Unsupported version 1");
 }
 
+TEST(MshFileTest, unsupported_data_size_v2)
+{
+    std::string file_name =
+        std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/unsupported-data-size-v2.msh");
+    EXPECT_THROW_MSG(
+        {
+            MshFile f(file_name);
+            f.parse();
+        },
+        "Unexpected data size found: 4");
+}
+
+TEST(MshFileTest, unsupported_data_size_v4)
+{
+    std::string file_name =
+        std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/unsupported-data-size-v4.msh");
+    EXPECT_THROW_MSG(
+        {
+            MshFile f(file_name);
+            f.parse();
+        },
+        "Unexpected data size found: 4");
+}
+
 TEST(MshFileTest, quad_v4_asc)
 {
     std::string file_name = std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/quad-v4.asc.msh");

--- a/test/MshFile_test.cpp
+++ b/test/MshFile_test.cpp
@@ -34,7 +34,6 @@ TEST(MshFileTest, non_existent_file)
     EXPECT_THAT_THROW_MSG({ MshFile f(file_name); },
                           MatchesRegex("Unable to open file '.+/non-existent-file.msh'."));
 }
-
 TEST(MshFileTest, missing_end_section_marker)
 {
     std::string file_name =
@@ -45,6 +44,19 @@ TEST(MshFileTest, missing_end_section_marker)
             f.parse();
         },
         "$EndMeshFormat tag not found.");
+}
+
+
+TEST(MshFileTest, unsupported_version)
+{
+    std::string file_name =
+        std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/unsupported-version.msh");
+    EXPECT_THROW_MSG(
+        {
+            MshFile f(file_name);
+            f.parse();
+        },
+        "Unsupported version 1");
 }
 
 TEST(MshFileTest, quad_v4_asc)

--- a/test/MshFile_test.cpp
+++ b/test/MshFile_test.cpp
@@ -104,9 +104,41 @@ TEST(MshFileTest, quad_v4_asc)
 
     auto nodes = f.get_nodes();
     EXPECT_EQ(nodes.size(), 9);
+    std::vector<int> dims = { 0, 0, 0, 0, 1, 1, 1, 1, 2 };
+    std::vector<std::vector<MshFile::Point>> pts = { { { 0., 0., 0. } },
+                                                     { { 1., 0., 0. } },
+                                                     { { 1., 1., 0. } },
+                                                     { { 0., 1., 0. } },
+
+                                                     {},
+                                                     {},
+                                                     {},
+                                                     {},
+
+                                                     { { 0.5, 0.5, 0. } } };
+    for (int i = 0; i < nodes.size(); i++) {
+        ASSERT_EQ(nodes[i].coordinates.size(), pts[i].size());
+        for (int j = 0; j < nodes[i].coordinates.size(); j++) {
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].x, pts[i][j].x);
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].y, pts[i][j].y);
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].z, pts[i][j].z);
+        }
+    }
 
     auto el_blks = f.get_element_blocks();
     EXPECT_EQ(el_blks.size(), 9);
+    std::vector<std::vector<std::vector<int>>> conn = {
+        { { 1 } },    { { 2 } },    { { 3 } },
+        { { 4 } },    { { 1, 2 } }, { { 2, 3 } },
+        { { 3, 4 } }, { { 4, 1 } }, { { 2, 5, 1 }, { 1, 5, 4 }, { 3, 5, 2 }, { 4, 5, 3 } },
+    };
+    for (int i = 0; i < el_blks.size(); i++) {
+        EXPECT_EQ(el_blks[i].elements.size(), conn[i].size());
+        for (int j = 0; j < el_blks[i].elements.size(); j++) {
+            for (int k = 0; k < el_blks[i].elements[j].node_tags.size(); k++)
+                EXPECT_EQ(el_blks[i].elements[j].node_tags[k], conn[i][j][k]);
+        }
+    }
 }
 
 TEST(MshFileTest, quad_v4_bin)
@@ -131,9 +163,39 @@ TEST(MshFileTest, quad_v4_bin)
 
     auto nodes = f.get_nodes();
     EXPECT_EQ(nodes.size(), 8);
+    std::vector<int> dims = { 0, 0, 0, 0, 1, 1, 1, 1 };
+    std::vector<std::vector<MshFile::Point>> pts = { { { 0., 0., 0. } },
+                                                     { { 1., 0., 0. } },
+                                                     { { 1., 1., 0. } },
+                                                     { { 0., 1., 0. } },
+                                                     {},
+                                                     {},
+                                                     {},
+                                                     {} };
+    for (int i = 0; i < nodes.size(); i++) {
+        EXPECT_EQ(nodes[i].coordinates.size(), pts[i].size());
+        for (int j = 0; j < nodes[i].coordinates.size(); j++) {
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].x, pts[i][j].x);
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].y, pts[i][j].y);
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].z, pts[i][j].z);
+        }
+    }
 
     auto el_blks = f.get_element_blocks();
     EXPECT_EQ(el_blks.size(), 4);
+    std::vector<std::vector<std::vector<int>>> conn = {
+        { { 1, 2 } },
+        { { 2, 3 } },
+        { { 3, 4 } },
+        { { 4, 1 } },
+    };
+    for (int i = 0; i < el_blks.size(); i++) {
+        EXPECT_EQ(el_blks[i].elements.size(), conn[i].size());
+        for (int j = 0; j < el_blks[i].elements.size(); j++) {
+            for (int k = 0; k < el_blks[i].elements[j].node_tags.size(); k++)
+                EXPECT_EQ(el_blks[i].elements[j].node_tags[k], conn[i][j][k]);
+        }
+    }
 }
 
 TEST(MshFileTest, quad_v2_asc)
@@ -146,9 +208,39 @@ TEST(MshFileTest, quad_v2_asc)
 
     auto nodes = f.get_nodes();
     EXPECT_EQ(nodes.size(), 4);
+    std::vector<int> dims = { 0, 0, 0, 0, 1, 1, 1, 1 };
+    std::vector<std::vector<MshFile::Point>> pts = { { { 0., 0., 0. } },
+                                                     { { 1., 0., 0. } },
+                                                     { { 1., 1., 0. } },
+                                                     { { 0., 1., 0. } },
+                                                     {},
+                                                     {},
+                                                     {},
+                                                     {} };
+    for (int i = 0; i < nodes.size(); i++) {
+        EXPECT_EQ(nodes[i].coordinates.size(), pts[i].size());
+        for (int j = 0; j < nodes[i].coordinates.size(); j++) {
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].x, pts[i][j].x);
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].y, pts[i][j].y);
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].z, pts[i][j].z);
+        }
+    }
 
     auto el_blks = f.get_element_blocks();
     EXPECT_EQ(el_blks.size(), 4);
+    std::vector<std::vector<std::vector<int>>> conn = {
+        { { 1, 2 } },
+        { { 2, 3 } },
+        { { 3, 4 } },
+        { { 4, 1 } },
+    };
+    for (int i = 0; i < el_blks.size(); i++) {
+        EXPECT_EQ(el_blks[i].elements.size(), conn[i].size());
+        for (int j = 0; j < el_blks[i].elements.size(); j++) {
+            for (int k = 0; k < el_blks[i].elements[j].node_tags.size(); k++)
+                EXPECT_EQ(el_blks[i].elements[j].node_tags[k], conn[i][j][k]);
+        }
+    }
 }
 
 TEST(MshFileTest, quad_v2_bin)
@@ -161,9 +253,39 @@ TEST(MshFileTest, quad_v2_bin)
 
     auto nodes = f.get_nodes();
     EXPECT_EQ(nodes.size(), 4);
+    std::vector<int> dims = { 0, 0, 0, 0, 1, 1, 1, 1 };
+    std::vector<std::vector<MshFile::Point>> pts = { { { 0., 0., 0. } },
+                                                     { { 1., 0., 0. } },
+                                                     { { 1., 1., 0. } },
+                                                     { { 0., 1., 0. } },
+                                                     {},
+                                                     {},
+                                                     {},
+                                                     {} };
+    for (int i = 0; i < nodes.size(); i++) {
+        EXPECT_EQ(nodes[i].coordinates.size(), pts[i].size());
+        for (int j = 0; j < nodes[i].coordinates.size(); j++) {
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].x, pts[i][j].x);
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].y, pts[i][j].y);
+            EXPECT_DOUBLE_EQ(nodes[i].coordinates[j].z, pts[i][j].z);
+        }
+    }
 
     auto el_blks = f.get_element_blocks();
     EXPECT_EQ(el_blks.size(), 4);
+    std::vector<std::vector<std::vector<int>>> conn = {
+        { { 1, 2 } },
+        { { 2, 3 } },
+        { { 3, 4 } },
+        { { 4, 1 } },
+    };
+    for (int i = 0; i < el_blks.size(); i++) {
+        EXPECT_EQ(el_blks[i].elements.size(), conn[i].size());
+        for (int j = 0; j < el_blks[i].elements.size(); j++) {
+            for (int k = 0; k < el_blks[i].elements[j].node_tags.size(); k++)
+                EXPECT_EQ(el_blks[i].elements[j].node_tags[k], conn[i][j][k]);
+        }
+    }
 }
 
 TEST(MshFileTest, two_blk)

--- a/test/MshFile_test.cpp
+++ b/test/MshFile_test.cpp
@@ -35,6 +35,18 @@ TEST(MshFileTest, non_existent_file)
                           MatchesRegex("Unable to open file '.+/non-existent-file.msh'."));
 }
 
+TEST(MshFileTest, missing_end_section_marker)
+{
+    std::string file_name =
+        std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/missing-end-section-marker.msh");
+    EXPECT_THROW_MSG(
+        {
+            MshFile f(file_name);
+            f.parse();
+        },
+        "$EndMeshFormat tag not found.");
+}
+
 TEST(MshFileTest, quad_v4_asc)
 {
     std::string file_name = std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/quad-v4.asc.msh");

--- a/test/MshFile_test.cpp
+++ b/test/MshFile_test.cpp
@@ -27,6 +27,14 @@ TEST(MshFileTest, header)
     EXPECT_TRUE(f.is_ascii());
 }
 
+TEST(MshFileTest, non_existent_file)
+{
+    std::string file_name =
+        std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/non-existent-file.msh");
+    EXPECT_THAT_THROW_MSG({ MshFile f(file_name); },
+                          MatchesRegex("Unable to open file '.+/non-existent-file.msh'."));
+}
+
 TEST(MshFileTest, quad_v4_asc)
 {
     std::string file_name = std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/quad-v4.asc.msh");

--- a/test/MshFile_test.cpp
+++ b/test/MshFile_test.cpp
@@ -154,11 +154,11 @@ TEST(MshFileTest, quad_v2_asc)
 
 TEST(MshFileTest, quad_v2_bin)
 {
-    std::string file_name = std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/quad-v2.asc.msh");
+    std::string file_name = std::string(GMSHPARSERCPP_ASSETS_DIR) + std::string("/quad-v2.bin.msh");
     MshFile f(file_name);
     EXPECT_NO_THROW({ f.parse(); });
     EXPECT_EQ(f.get_version(), 2.2);
-    EXPECT_TRUE(f.is_ascii());
+    EXPECT_FALSE(f.is_ascii());
 
     auto nodes = f.get_nodes();
     EXPECT_EQ(nodes.size(), 4);

--- a/test/assets/missing-end-section-marker.msh
+++ b/test/assets/missing-end-section-marker.msh
@@ -1,0 +1,2 @@
+$MeshFormat
+    4.1 0 8

--- a/test/assets/unsupported-data-size-v2.msh
+++ b/test/assets/unsupported-data-size-v2.msh
@@ -1,0 +1,3 @@
+$MeshFormat
+2.2 0 4
+$EndMeshFormat

--- a/test/assets/unsupported-data-size-v4.msh
+++ b/test/assets/unsupported-data-size-v4.msh
@@ -1,0 +1,3 @@
+$MeshFormat
+4.1 0 4
+$EndMeshFormat

--- a/test/assets/unsupported-version.msh
+++ b/test/assets/unsupported-version.msh
@@ -1,0 +1,3 @@
+$MeshFormat
+1.0 0 8
+$EndMeshFormat


### PR DESCRIPTION
- Adding library specific exception
- Updating tests
- Adding a unit test for opening non-existent file
- Adding a unit test for missing end section marker
- Adding a unit test for unsupported version
- Adding unit tests for unexpected data size
- Fixing reading of version 2 binary files + test
- MshFile::get_element_dimension and get_nodes_per_element are static
- Clean up in CodeCoverage.cmake
- Improving unit tests for reading the quad mesh file
